### PR TITLE
fix: Correct answer for Constitution Question ID 28

### DIFF
--- a/latvian_citizenship_questions.json
+++ b/latvian_citizenship_questions.json
@@ -1090,7 +1090,7 @@
         "Tikai Latvijas pilsoņiem",
         "Tikai citu valstu pilsoņiem"
       ],
-      "correctAnswer": 1
+      "correctAnswer": 0
     },
     {
       "id": 29,


### PR DESCRIPTION
## Summary
Fixed incorrect answer for Constitution Question ID 28 about the right to freely leave Latvia.

## Issue
The question "Kam ir tiesības brīvi izbraukt no Latvijas?" (Who has the right to freely leave Latvia?) had an incorrect answer set to "Tikai Latvijas pilsoņiem" (Only Latvian citizens).

## Solution
According to Article 98 of the Latvian Constitution (Satversme): "Ikvienam ir tiesības brīvi izbraukt no Latvijas" - Everyone has the right to freely leave Latvia.

Changed the correct answer from index 1 to index 0, which corresponds to "Ikvienam" (Everyone).

## Verification
- Reviewed all 144 questions (80 history + 64 constitution)
- Cross-checked with official Latvian Constitution text
- Found this to be the only incorrect answer in the database

🤖 Generated with [Claude Code](https://claude.ai/code)