### PR TITLE
fix: Remove favicon 404 errors from console

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="lv">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
     <title>Latvijas Pilsonības Naturalizācijas Eksāmens</title>
     <meta name="description" content="Prakses eksāmens Latvijas pilsonības naturalizācijas pārbaudījumam" />

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -70,7 +70,6 @@ const PRODUCTION_CONFIG: NetworkMonitorConfig = {
   testTimeout: 8000, // 8 seconds (longer timeout for production)
   testUrls: [
     '/', // Test current domain root
-    '/favicon.ico', // Test favicon (should exist)
   ],
   enablePeriodicChecks: true,
   trackQualityChanges: false, // Reduce logging in production
@@ -83,7 +82,6 @@ const DEVELOPMENT_CONFIG: NetworkMonitorConfig = {
   testTimeout: 5000, // 5 seconds
   testUrls: [
     '/', // Test current domain root
-    '/favicon.ico', // Test favicon
   ],
   enablePeriodicChecks: true,
   trackQualityChanges: true,


### PR DESCRIPTION
## Summary
• Remove non-existent favicon reference from index.html
• Remove /favicon.ico from network status test URLs
• Prevents repeated console 404 errors every 30 seconds

## Test plan
- [x] Verify no more favicon 404 errors in browser console
- [x] Confirm network status monitoring still works with remaining test URL
- [x] Test both development and production configurations

🤖 Generated with [Claude Code](https://claude.ai/code)