### PR TITLE
feat: Improve partial test UX - remove back button, center indicators, filter progress displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="lv">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
     <title>Latvijas Pilsonības Naturalizācijas Eksāmens</title>
     <meta name="description" content="Prakses eksāmens Latvijas pilsonības naturalizācijas pārbaudījumam" />

--- a/src/__tests__/sessionInitialization.test.tsx
+++ b/src/__tests__/sessionInitialization.test.tsx
@@ -1,0 +1,430 @@
+/**
+ * @fileoverview Tests for session initialization logic and section configuration handling
+ *
+ * Specifically tests the fix for Issue #70: Session persists when starting new test
+ * with different section selection
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { loadSessionData, clearSessionData } from '@/utils/sessionStorage'
+import { arraysEqual } from '@/utils/arrayUtils'
+import type { SessionData, TestState } from '@/types'
+
+// Mock the session storage utilities
+vi.mock('@/utils/sessionStorage', () => ({
+  loadSessionData: vi.fn(),
+  clearSessionData: vi.fn(),
+  saveSessionData: vi.fn(),
+}))
+
+// Mock array utils (though it should work correctly)
+vi.mock('@/utils/arrayUtils', () => ({
+  arraysEqual: vi.fn(),
+}))
+
+const mockLoadSessionData = vi.mocked(loadSessionData)
+const mockClearSessionData = vi.mocked(clearSessionData)
+const mockArraysEqual = vi.mocked(arraysEqual)
+
+describe('Session Initialization Logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClearSessionData.mockReturnValue(true)
+  })
+
+  const createMockSessionData = (
+    selectedSectionIds: string[]
+  ): SessionData => ({
+    testState: {
+      anthemText: '',
+      historyAnswers: {},
+      constitutionAnswers: {},
+      startTime: Date.now(),
+      lastSaved: 0,
+      isCompleted: false,
+      currentSection: 'anthem' as const,
+      selectedQuestions: {
+        anthem: [],
+        history: [],
+        constitution: [],
+      },
+      enabledSections: {
+        anthem: selectedSectionIds.includes('anthem'),
+        history: selectedSectionIds.includes('history'),
+        constitution: selectedSectionIds.includes('constitution'),
+      },
+      selectedSectionIds,
+      testConfiguration: {
+        totalSections: selectedSectionIds.length,
+        sectionNames: selectedSectionIds,
+        isPartialTest: selectedSectionIds.length < 3,
+      },
+      metadata: {
+        sessionId: 'test-session',
+        timezone: 'UTC',
+        attemptNumber: 1,
+        darkMode: false,
+      },
+    } as TestState,
+    selectedQuestions: {
+      anthem: [],
+      history: [],
+      constitution: [],
+    },
+    sessionId: 'test-session',
+    expiresAt: Date.now() + 7200000, // 2 hours
+    version: '1.0.0',
+    metadata: {
+      sessionId: 'test-session',
+      timezone: 'UTC',
+      attemptNumber: 1,
+      darkMode: false,
+      lastUpdated: Date.now(),
+    },
+  })
+
+  describe('Session Configuration Comparison', () => {
+    it('should detect when configurations match', () => {
+      // Setup: Existing session with anthem and history
+      const existingConfig = ['anthem', 'history']
+      const newConfig = ['anthem', 'history']
+
+      mockArraysEqual.mockReturnValue(true)
+
+      const result = arraysEqual(existingConfig, newConfig)
+
+      expect(result).toBe(true)
+      expect(mockArraysEqual).toHaveBeenCalledWith(existingConfig, newConfig)
+    })
+
+    it('should detect when configurations differ', () => {
+      // Setup: Existing session with anthem and history, new config with only anthem
+      const existingConfig = ['anthem', 'history']
+      const newConfig = ['anthem']
+
+      mockArraysEqual.mockReturnValue(false)
+
+      const result = arraysEqual(existingConfig, newConfig)
+
+      expect(result).toBe(false)
+      expect(mockArraysEqual).toHaveBeenCalledWith(existingConfig, newConfig)
+    })
+
+    it('should detect when order differs but content is same', () => {
+      // Setup: Same sections in different order should be considered equal
+      const existingConfig = ['anthem', 'history', 'constitution']
+      const newConfig = ['history', 'constitution', 'anthem']
+
+      mockArraysEqual.mockReturnValue(true) // Our arraysEqual function handles order-independence
+
+      const result = arraysEqual(existingConfig, newConfig)
+
+      expect(result).toBe(true)
+      expect(mockArraysEqual).toHaveBeenCalledWith(existingConfig, newConfig)
+    })
+  })
+
+  describe('Session Loading with Navigation State', () => {
+    it('should load existing session when configurations match', () => {
+      // Setup: Navigation state with anthem and history
+      const navigationSections = ['anthem', 'history']
+      const existingSession = createMockSessionData(['anthem', 'history'])
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(true)
+
+      // Simulate the logic from App.tsx
+      const hasNavigationState = navigationSections.length > 0
+
+      if (hasNavigationState) {
+        const existingSessionResult = loadSessionData()
+
+        if (
+          existingSessionResult.success &&
+          existingSessionResult.sessionData
+        ) {
+          const existingConfig =
+            existingSessionResult.sessionData.testState.selectedSectionIds || []
+          const newConfig = navigationSections
+
+          const shouldClearSession = !arraysEqual(existingConfig, newConfig)
+
+          expect(shouldClearSession).toBe(false)
+          expect(mockClearSessionData).not.toHaveBeenCalled()
+        }
+      }
+
+      expect(mockLoadSessionData).toHaveBeenCalled()
+      expect(mockArraysEqual).toHaveBeenCalledWith(
+        ['anthem', 'history'],
+        navigationSections
+      )
+    })
+
+    it('should clear session when configurations differ', () => {
+      // Setup: Navigation state with only anthem, existing session with anthem and history
+      const navigationSections = ['anthem']
+      const existingSession = createMockSessionData(['anthem', 'history'])
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(false)
+
+      // Simulate the logic from App.tsx
+      const hasNavigationState = navigationSections.length > 0
+      let shouldCreateNewSession = false
+
+      if (hasNavigationState) {
+        const existingSessionResult = loadSessionData()
+
+        if (
+          existingSessionResult.success &&
+          existingSessionResult.sessionData
+        ) {
+          const existingConfig =
+            existingSessionResult.sessionData.testState.selectedSectionIds || []
+          const newConfig = navigationSections
+
+          if (!arraysEqual(existingConfig, newConfig)) {
+            clearSessionData() // Would call clearSession() in real implementation
+            shouldCreateNewSession = true
+          }
+        }
+      }
+
+      expect(shouldCreateNewSession).toBe(true)
+      expect(mockLoadSessionData).toHaveBeenCalled()
+      expect(mockArraysEqual).toHaveBeenCalledWith(
+        ['anthem', 'history'],
+        navigationSections
+      )
+      expect(mockClearSessionData).toHaveBeenCalled()
+    })
+
+    it('should create new session when no existing session found', () => {
+      // Setup: Navigation state with sections but no existing session
+      const navigationSections = ['constitution']
+
+      mockLoadSessionData.mockReturnValue({
+        success: false,
+        error: {
+          code: 'NO_SESSION_DATA',
+          message: 'No session data found',
+          timestamp: Date.now(),
+          severity: 'warning',
+        },
+      })
+
+      // Simulate the logic from App.tsx
+      const hasNavigationState = navigationSections.length > 0
+      let shouldCreateNewSession = false
+
+      if (hasNavigationState) {
+        const existingSessionResult = loadSessionData()
+
+        if (
+          existingSessionResult.success &&
+          existingSessionResult.sessionData
+        ) {
+          // This branch won't execute due to success: false
+        } else {
+          shouldCreateNewSession = true
+        }
+      }
+
+      expect(shouldCreateNewSession).toBe(true)
+      expect(mockLoadSessionData).toHaveBeenCalled()
+      expect(mockClearSessionData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty section configurations', () => {
+      const existingConfig: string[] = []
+      const newConfig: string[] = []
+
+      mockArraysEqual.mockReturnValue(true)
+
+      const result = arraysEqual(existingConfig, newConfig)
+
+      expect(result).toBe(true)
+      expect(mockArraysEqual).toHaveBeenCalledWith(existingConfig, newConfig)
+    })
+
+    it('should handle null/undefined configurations gracefully', () => {
+      const navigationSections = ['anthem']
+      const existingSession = createMockSessionData(['anthem'])
+
+      // Simulate missing selectedSectionIds
+      existingSession.testState.selectedSectionIds = undefined as any
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(false)
+
+      // Simulate the logic from App.tsx with fallback to empty array
+      const hasNavigationState = navigationSections.length > 0
+
+      if (hasNavigationState) {
+        const existingSessionResult = loadSessionData()
+
+        if (
+          existingSessionResult.success &&
+          existingSessionResult.sessionData
+        ) {
+          const existingConfig =
+            existingSessionResult.sessionData.testState.selectedSectionIds || []
+          const newConfig = navigationSections
+
+          // Should handle undefined by falling back to empty array
+          expect(existingConfig).toEqual([])
+          expect(arraysEqual(existingConfig, newConfig)).toBe(false)
+        }
+      }
+
+      expect(mockArraysEqual).toHaveBeenCalledWith([], navigationSections)
+    })
+
+    it('should handle session data loading errors', () => {
+      const navigationSections = ['anthem', 'history']
+
+      mockLoadSessionData.mockReturnValue({
+        success: false,
+        error: {
+          code: 'STORAGE_UNAVAILABLE',
+          message: 'Session storage is not available',
+          timestamp: Date.now(),
+          severity: 'error',
+        },
+      })
+
+      // Simulate the logic from App.tsx
+      const hasNavigationState = navigationSections.length > 0
+      let shouldCreateNewSession = false
+
+      if (hasNavigationState) {
+        const existingSessionResult = loadSessionData()
+
+        if (
+          existingSessionResult.success &&
+          existingSessionResult.sessionData
+        ) {
+          // This won't execute due to success: false
+        } else {
+          shouldCreateNewSession = true
+        }
+      }
+
+      expect(shouldCreateNewSession).toBe(true)
+      expect(mockClearSessionData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Real-world Scenarios from Issue #70', () => {
+    it('should handle Test Case 1: Same Selection (should keep session)', () => {
+      // User selects A, B, C → start test → return to landing → select same A, B, C → start test
+      const sections = ['anthem', 'history', 'constitution']
+      const existingSession = createMockSessionData(sections)
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(true)
+
+      let shouldClearSession = false
+      let shouldLoadExisting = false
+
+      const existingSessionResult = loadSessionData()
+      if (existingSessionResult.success && existingSessionResult.sessionData) {
+        const existingConfig =
+          existingSessionResult.sessionData.testState.selectedSectionIds || []
+        const newConfig = sections
+
+        if (!arraysEqual(existingConfig, newConfig)) {
+          shouldClearSession = true
+        } else {
+          shouldLoadExisting = true
+        }
+      }
+
+      expect(shouldClearSession).toBe(false)
+      expect(shouldLoadExisting).toBe(true)
+      expect(mockClearSessionData).not.toHaveBeenCalled()
+    })
+
+    it('should handle Test Case 2: Different Selection (should clear session)', () => {
+      // User selects A, B → start test → return to landing → select B, C → start test
+      const existingSections = ['anthem', 'history']
+      const newSections = ['history', 'constitution']
+      const existingSession = createMockSessionData(existingSections)
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(false)
+
+      let shouldClearSession = false
+      let shouldCreateNew = false
+
+      const existingSessionResult = loadSessionData()
+      if (existingSessionResult.success && existingSessionResult.sessionData) {
+        const existingConfig =
+          existingSessionResult.sessionData.testState.selectedSectionIds || []
+        const newConfig = newSections
+
+        if (!arraysEqual(existingConfig, newConfig)) {
+          clearSessionData()
+          shouldClearSession = true
+          shouldCreateNew = true
+        }
+      }
+
+      expect(shouldClearSession).toBe(true)
+      expect(shouldCreateNew).toBe(true)
+      expect(mockClearSessionData).toHaveBeenCalled()
+    })
+
+    it('should handle Test Case 3: Subset Selection (should clear session)', () => {
+      // User selects all A, B, C → start test → return to landing → select only A → start test
+      const existingSections = ['anthem', 'history', 'constitution']
+      const newSections = ['anthem']
+      const existingSession = createMockSessionData(existingSections)
+
+      mockLoadSessionData.mockReturnValue({
+        success: true,
+        sessionData: existingSession,
+      })
+      mockArraysEqual.mockReturnValue(false)
+
+      let shouldClearSession = false
+
+      const existingSessionResult = loadSessionData()
+      if (existingSessionResult.success && existingSessionResult.sessionData) {
+        const existingConfig =
+          existingSessionResult.sessionData.testState.selectedSectionIds || []
+        const newConfig = newSections
+
+        if (!arraysEqual(existingConfig, newConfig)) {
+          clearSessionData()
+          shouldClearSession = true
+        }
+      }
+
+      expect(shouldClearSession).toBe(true)
+      expect(mockClearSessionData).toHaveBeenCalled()
+      expect(mockArraysEqual).toHaveBeenCalledWith(
+        existingSections,
+        newSections
+      )
+    })
+  })
+})

--- a/src/components/exam/ExamResults.tsx
+++ b/src/components/exam/ExamResults.tsx
@@ -37,13 +37,12 @@ export function ExamResults({ results, onRetakeExam }: ExamResultsProps) {
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>Nav pieejami rezultāti</AlertTitle>
           <AlertDescription>
-            Eksāmena rezultāti nav pieejami. Lūdzu, vispirms nokārtojiet eksāmenu.
+            Eksāmena rezultāti nav pieejami. Lūdzu, vispirms nokārtojiet
+            eksāmenu.
           </AlertDescription>
         </Alert>
         <div className="mt-6">
-          <Button onClick={onRetakeExam}>
-            Sākt eksāmenu
-          </Button>
+          <Button onClick={onRetakeExam}>Sākt eksāmenu</Button>
         </div>
       </div>
     )
@@ -162,68 +161,68 @@ export function ExamResults({ results, onRetakeExam }: ExamResultsProps) {
                   >
                     {results.anthem.accuracy.toFixed(1)}% precizitāte
                   </Badge>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => toggleSection('anthem')}
-                className="flex items-center space-x-1"
-                aria-expanded={expandedSections.has('anthem')}
-                aria-controls="anthem-details"
-              >
-                <span>Detaļas</span>
-                {expandedSections.has('anthem') ? (
-                  <ChevronUp className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
-          </CardHeader>
-
-          {expandedSections.has('anthem') && (
-            <CardContent
-              id="anthem-details"
-              className="pt-0"
-              role="region"
-              aria-labelledby="anthem-title"
-            >
-              <div className="space-y-4">
-                <div>
-                  <p className="text-sm font-medium mb-2">Rezultāts</p>
-                  <div className="text-sm space-y-1 text-muted-foreground">
-                    <div>
-                      Pareizi rakstu: {results.anthem.correctCharacters}/
-                      {results.anthem.totalCharacters}
-                    </div>
-                    <div>
-                      Precizitāte: {results.anthem.accuracy.toFixed(2)}%
-                    </div>
-                    <div>Nepieciešamā precizitāte: 75%</div>
-                  </div>
                 </div>
-
-                {results.anthem.characterDifferences.length > 0 && (
-                  <Alert>
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle>Atrastās kļūdas</AlertTitle>
-                    <AlertDescription className="mt-2">
-                      <div className="text-sm space-y-1">
-                        {results.anthem.analysis.errorPatterns
-                          .slice(0, 3)
-                          .map((pattern, index) => (
-                            <div key={index}>
-                              • {pattern.suggestion} ({pattern.count} reizes)
-                            </div>
-                          ))}
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => toggleSection('anthem')}
+                  className="flex items-center space-x-1"
+                  aria-expanded={expandedSections.has('anthem')}
+                  aria-controls="anthem-details"
+                >
+                  <span>Detaļas</span>
+                  {expandedSections.has('anthem') ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                </Button>
               </div>
-            </CardContent>
-          )}
-        </Card>
+            </CardHeader>
+
+            {expandedSections.has('anthem') && (
+              <CardContent
+                id="anthem-details"
+                className="pt-0"
+                role="region"
+                aria-labelledby="anthem-title"
+              >
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-sm font-medium mb-2">Rezultāts</p>
+                    <div className="text-sm space-y-1 text-muted-foreground">
+                      <div>
+                        Pareizi rakstu: {results.anthem.correctCharacters}/
+                        {results.anthem.totalCharacters}
+                      </div>
+                      <div>
+                        Precizitāte: {results.anthem.accuracy.toFixed(2)}%
+                      </div>
+                      <div>Nepieciešamā precizitāte: 75%</div>
+                    </div>
+                  </div>
+
+                  {results.anthem.characterDifferences.length > 0 && (
+                    <Alert>
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>Atrastās kļūdas</AlertTitle>
+                      <AlertDescription className="mt-2">
+                        <div className="text-sm space-y-1">
+                          {results.anthem.analysis.errorPatterns
+                            .slice(0, 3)
+                            .map((pattern, index) => (
+                              <div key={index}>
+                                • {pattern.suggestion} ({pattern.count} reizes)
+                              </div>
+                            ))}
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              </CardContent>
+            )}
+          </Card>
         )}
 
         {/* History Results */}
@@ -238,68 +237,76 @@ export function ExamResults({ results, onRetakeExam }: ExamResultsProps) {
                   >
                     {results.history.correct}/{results.history.total} pareizi
                   </Badge>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => toggleSection('history')}
-                className="flex items-center space-x-1"
-              >
-                <span>Detaļas</span>
-                {expandedSections.has('history') ? (
-                  <ChevronUp className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
-          </CardHeader>
-
-          {expandedSections.has('history') && (
-            <CardContent className="pt-0">
-              <div className="space-y-4">
-                <div className="flex justify-between text-sm">
-                  <span>Rezultāts: {results.history.percentage}%</span>
-                  <span className="text-muted-foreground">
-                    Nepieciešams: ≥70%
-                  </span>
                 </div>
-
-                {results.history.answers.some((a) => !a.isCorrect) && (
-                  <Alert>
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle>Nepareizās atbildes</AlertTitle>
-                    <AlertDescription className="mt-2">
-                      <div className="space-y-2">
-                        {results.history.answers
-                          .filter((a) => !a.isCorrect)
-                          .slice(0, 5)
-                          .map((answer, index) => (
-                            <div
-                              key={index}
-                              className="text-sm p-2 bg-muted rounded"
-                            >
-                              <div className="font-medium">
-                                {answer.question.question}
-                              </div>
-                              <div className="text-red-600 mt-1">
-                                Jūsu atbilde:{' '}
-                                {answer.question.options[answer.selectedAnswer]}
-                              </div>
-                              <div className="text-green-600">
-                                Pareizā atbilde:{' '}
-                                {answer.question.options[answer.correctAnswer]}
-                              </div>
-                            </div>
-                          ))}
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => toggleSection('history')}
+                  className="flex items-center space-x-1"
+                >
+                  <span>Detaļas</span>
+                  {expandedSections.has('history') ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                </Button>
               </div>
-            </CardContent>
-          )}
-        </Card>
+            </CardHeader>
+
+            {expandedSections.has('history') && (
+              <CardContent className="pt-0">
+                <div className="space-y-4">
+                  <div className="flex justify-between text-sm">
+                    <span>Rezultāts: {results.history.percentage}%</span>
+                    <span className="text-muted-foreground">
+                      Nepieciešams: ≥70%
+                    </span>
+                  </div>
+
+                  {results.history.answers.some((a) => !a.isCorrect) && (
+                    <Alert>
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>Nepareizās atbildes</AlertTitle>
+                      <AlertDescription className="mt-2">
+                        <div className="space-y-2">
+                          {results.history.answers
+                            .filter((a) => !a.isCorrect)
+                            .slice(0, 5)
+                            .map((answer, index) => (
+                              <div
+                                key={index}
+                                className="text-sm p-2 bg-muted rounded"
+                              >
+                                <div className="font-medium">
+                                  {answer.question.question}
+                                </div>
+                                <div className="text-red-600 mt-1">
+                                  Jūsu atbilde:{' '}
+                                  {
+                                    answer.question.options[
+                                      answer.selectedAnswer
+                                    ]
+                                  }
+                                </div>
+                                <div className="text-green-600">
+                                  Pareizā atbilde:{' '}
+                                  {
+                                    answer.question.options[
+                                      answer.correctAnswer
+                                    ]
+                                  }
+                                </div>
+                              </div>
+                            ))}
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              </CardContent>
+            )}
+          </Card>
         )}
 
         {/* Constitution Results */}
@@ -309,76 +316,84 @@ export function ExamResults({ results, onRetakeExam }: ExamResultsProps) {
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-3">
                   <CardTitle>Konstitūcijas jautājumi</CardTitle>
-                <Badge
-                  variant={
-                    results.constitution.passed ? 'default' : 'destructive'
-                  }
-                >
-                  {results.constitution.correct}/{results.constitution.total}{' '}
-                  pareizi
-                </Badge>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => toggleSection('constitution')}
-                className="flex items-center space-x-1"
-              >
-                <span>Detaļas</span>
-                {expandedSections.has('constitution') ? (
-                  <ChevronUp className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
-          </CardHeader>
-
-          {expandedSections.has('constitution') && (
-            <CardContent className="pt-0">
-              <div className="space-y-4">
-                <div className="flex justify-between text-sm">
-                  <span>Rezultāts: {results.constitution.percentage}%</span>
-                  <span className="text-muted-foreground">
-                    Nepieciešams: ≥62.5%
-                  </span>
+                  <Badge
+                    variant={
+                      results.constitution.passed ? 'default' : 'destructive'
+                    }
+                  >
+                    {results.constitution.correct}/{results.constitution.total}{' '}
+                    pareizi
+                  </Badge>
                 </div>
-
-                {results.constitution.answers.some((a) => !a.isCorrect) && (
-                  <Alert>
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle>Nepareizās atbildes</AlertTitle>
-                    <AlertDescription className="mt-2">
-                      <div className="space-y-2">
-                        {results.constitution.answers
-                          .filter((a) => !a.isCorrect)
-                          .slice(0, 5)
-                          .map((answer, index) => (
-                            <div
-                              key={index}
-                              className="text-sm p-2 bg-muted rounded"
-                            >
-                              <div className="font-medium">
-                                {answer.question.question}
-                              </div>
-                              <div className="text-red-600 mt-1">
-                                Jūsu atbilde:{' '}
-                                {answer.question.options[answer.selectedAnswer]}
-                              </div>
-                              <div className="text-green-600">
-                                Pareizā atbilde:{' '}
-                                {answer.question.options[answer.correctAnswer]}
-                              </div>
-                            </div>
-                          ))}
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => toggleSection('constitution')}
+                  className="flex items-center space-x-1"
+                >
+                  <span>Detaļas</span>
+                  {expandedSections.has('constitution') ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                </Button>
               </div>
-            </CardContent>
-          )}
-        </Card>
+            </CardHeader>
+
+            {expandedSections.has('constitution') && (
+              <CardContent className="pt-0">
+                <div className="space-y-4">
+                  <div className="flex justify-between text-sm">
+                    <span>Rezultāts: {results.constitution.percentage}%</span>
+                    <span className="text-muted-foreground">
+                      Nepieciešams: ≥62.5%
+                    </span>
+                  </div>
+
+                  {results.constitution.answers.some((a) => !a.isCorrect) && (
+                    <Alert>
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>Nepareizās atbildes</AlertTitle>
+                      <AlertDescription className="mt-2">
+                        <div className="space-y-2">
+                          {results.constitution.answers
+                            .filter((a) => !a.isCorrect)
+                            .slice(0, 5)
+                            .map((answer, index) => (
+                              <div
+                                key={index}
+                                className="text-sm p-2 bg-muted rounded"
+                              >
+                                <div className="font-medium">
+                                  {answer.question.question}
+                                </div>
+                                <div className="text-red-600 mt-1">
+                                  Jūsu atbilde:{' '}
+                                  {
+                                    answer.question.options[
+                                      answer.selectedAnswer
+                                    ]
+                                  }
+                                </div>
+                                <div className="text-green-600">
+                                  Pareizā atbilde:{' '}
+                                  {
+                                    answer.question.options[
+                                      answer.correctAnswer
+                                    ]
+                                  }
+                                </div>
+                              </div>
+                            ))}
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              </CardContent>
+            )}
+          </Card>
         )}
       </div>
 

--- a/src/components/exam/SubmissionPanel.tsx
+++ b/src/components/exam/SubmissionPanel.tsx
@@ -40,7 +40,8 @@ export function SubmissionPanel({
 
   // Get detailed validation status for each section
   const getDetailedValidationStatus = () => {
-    const { anthemText, historyAnswers, constitutionAnswers, enabledSections } = testState
+    const { anthemText, historyAnswers, constitutionAnswers, enabledSections } =
+      testState
 
     // Only validate enabled sections
     const anthemIssues: string[] = []
@@ -54,7 +55,9 @@ export function SubmissionPanel({
       } else {
         // Check if all 8 lines have content (at least one letter each)
         // Filter out empty lines to handle the extra newline after 4th line
-        const lines = anthemText.split('\n').filter((line) => line.trim() !== '')
+        const lines = anthemText
+          .split('\n')
+          .filter((line) => line.trim() !== '')
         const requiredLines = 8
         let emptyLineCount = 0
 
@@ -106,7 +109,9 @@ export function SubmissionPanel({
           ([, answer]) => ![0, 1, 2].includes(answer)
         )
         if (invalidAnswers.length > 0) {
-          constitutionIssues.push(`${invalidAnswers.length} nepareizas atbildes`)
+          constitutionIssues.push(
+            `${invalidAnswers.length} nepareizas atbildes`
+          )
         }
       }
     }
@@ -198,45 +203,52 @@ export function SubmissionPanel({
           <h4 className="font-medium">Sekciju statuss</h4>
 
           <div className="space-y-3">
-            <div className="flex items-center justify-between p-3 rounded-lg border">
-              <div className="flex items-center gap-3">
-                {getStatusIcon(anthemStatus)}
-                <span className="font-medium">Valsts himna</span>
+            {testState.enabledSections.anthem && (
+              <div className="flex items-center justify-between p-3 rounded-lg border">
+                <div className="flex items-center gap-3">
+                  {getStatusIcon(anthemStatus)}
+                  <span className="font-medium">Valsts himna</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {Math.round(anthemProgress)}%
+                  </span>
+                  {getStatusBadge(anthemStatus)}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">
-                  {Math.round(anthemProgress)}%
-                </span>
-                {getStatusBadge(anthemStatus)}
-              </div>
-            </div>
+            )}
 
-            <div className="flex items-center justify-between p-3 rounded-lg border">
-              <div className="flex items-center gap-3">
-                {getStatusIcon(historyStatus)}
-                <span className="font-medium">Vēstures jautājumi</span>
+            {testState.enabledSections.history && (
+              <div className="flex items-center justify-between p-3 rounded-lg border">
+                <div className="flex items-center gap-3">
+                  {getStatusIcon(historyStatus)}
+                  <span className="font-medium">Vēstures jautājumi</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {historyAnswered}/
+                    {SCORING_THRESHOLDS.HISTORY_TOTAL_QUESTIONS}
+                  </span>
+                  {getStatusBadge(historyStatus)}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">
-                  {historyAnswered}/{SCORING_THRESHOLDS.HISTORY_TOTAL_QUESTIONS}
-                </span>
-                {getStatusBadge(historyStatus)}
-              </div>
-            </div>
+            )}
 
-            <div className="flex items-center justify-between p-3 rounded-lg border">
-              <div className="flex items-center gap-3">
-                {getStatusIcon(constitutionStatus)}
-                <span className="font-medium">Konstitūcijas jautājumi</span>
+            {testState.enabledSections.constitution && (
+              <div className="flex items-center justify-between p-3 rounded-lg border">
+                <div className="flex items-center gap-3">
+                  {getStatusIcon(constitutionStatus)}
+                  <span className="font-medium">Konstitūcijas jautājumi</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {constitutionAnswered}/
+                    {SCORING_THRESHOLDS.CONSTITUTION_TOTAL_QUESTIONS}
+                  </span>
+                  {getStatusBadge(constitutionStatus)}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">
-                  {constitutionAnswered}/
-                  {SCORING_THRESHOLDS.CONSTITUTION_TOTAL_QUESTIONS}
-                </span>
-                {getStatusBadge(constitutionStatus)}
-              </div>
-            </div>
+            )}
           </div>
         </div>
 

--- a/src/components/layout/BottomProgressBar.tsx
+++ b/src/components/layout/BottomProgressBar.tsx
@@ -8,14 +8,28 @@ import type { SectionStatus } from './ProgressIndicator'
 interface BottomProgressBarProps {
   sections: SectionStatus[]
   overallProgress: number
+  enabledSections?: {
+    anthem: boolean
+    history: boolean
+    constitution: boolean
+  }
   className?: string
 }
 
 export function BottomProgressBar({
   sections,
   overallProgress,
+  enabledSections,
   className,
 }: BottomProgressBarProps) {
+  // Filter sections if enabledSections is provided
+  const filteredSections = enabledSections
+    ? sections.filter((section) => {
+        const sectionId = section.id as keyof typeof enabledSections
+        return enabledSections[sectionId]
+      })
+    : sections
+
   const getSectionIcon = (section: SectionStatus) => {
     if (section.isCompleted) {
       return <CheckCircle className="h-3 w-3 text-green-500" />
@@ -53,7 +67,7 @@ export function BottomProgressBar({
 
         {/* Section Progress */}
         <div className="flex items-center justify-center gap-3 sm:gap-6 flex-wrap overflow-x-auto pb-2 sm:pb-0">
-          {sections.map((section) => (
+          {filteredSections.map((section) => (
             <div
               key={section.id}
               className="flex items-center gap-1.5 sm:gap-2 min-w-0 flex-shrink-0"

--- a/src/components/layout/ExamHeader.tsx
+++ b/src/components/layout/ExamHeader.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 interface ExamHeaderProps {
   title?: string
   subtitle?: string
+  partialTestIndicator?: ReactNode
   children?: ReactNode
   className?: string
 }
@@ -11,19 +12,23 @@ interface ExamHeaderProps {
 export function ExamHeader({
   title = 'Latvijas Pilsonības Naturalizācijas Eksāmens',
   subtitle = 'Prakses eksāmens pilsonības iegūšanai',
+  partialTestIndicator,
   children,
   className,
 }: ExamHeaderProps) {
   return (
-    <header role="banner" className={cn('border-b border-border', className)}>
+    <header role="banner" className={className}>
       <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-6 max-w-6xl">
         <div className="text-center">
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-foreground mb-2 leading-tight">
             {title}
           </h1>
-          <p className="text-sm sm:text-base md:text-lg text-muted-foreground mb-4 max-w-2xl mx-auto">
+          <p className="text-sm sm:text-base md:text-lg text-muted-foreground mb-2 max-w-2xl mx-auto">
             {subtitle}
           </p>
+          {partialTestIndicator && (
+            <div className="mb-4">{partialTestIndicator}</div>
+          )}
           {children && (
             <div
               className="flex justify-center overflow-x-auto pb-2"

--- a/src/components/layout/ProgressIndicator.tsx
+++ b/src/components/layout/ProgressIndicator.tsx
@@ -15,13 +15,27 @@ export interface SectionStatus {
 
 interface ProgressIndicatorProps {
   sections: SectionStatus[]
+  enabledSections?: {
+    anthem: boolean
+    history: boolean
+    constitution: boolean
+  }
   className?: string
 }
 
 export function ProgressIndicator({
   sections,
+  enabledSections,
   className,
 }: ProgressIndicatorProps) {
+  // Filter sections if enabledSections is provided
+  const filteredSections = enabledSections
+    ? sections.filter((section) => {
+        const sectionId = section.id as keyof typeof enabledSections
+        return enabledSections[sectionId]
+      })
+    : sections
+
   const getSectionIcon = (section: SectionStatus) => {
     if (section.isCompleted) {
       return <CheckCircle className="h-3 w-3 text-green-500" />
@@ -39,7 +53,7 @@ export function ProgressIndicator({
         className
       )}
     >
-      {sections.map((section) => (
+      {filteredSections.map((section) => (
         <div
           key={section.id}
           className="flex items-center gap-2 sm:gap-3 min-w-0 flex-shrink-0"

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -70,7 +70,6 @@ const PRODUCTION_CONFIG: NetworkMonitorConfig = {
   testTimeout: 8000, // 8 seconds (longer timeout for production)
   testUrls: [
     '/', // Test current domain root
-    '/favicon.ico', // Test favicon (should exist)
   ],
   enablePeriodicChecks: true,
   trackQualityChanges: false, // Reduce logging in production
@@ -83,7 +82,6 @@ const DEVELOPMENT_CONFIG: NetworkMonitorConfig = {
   testTimeout: 5000, // 5 seconds
   testUrls: [
     '/', // Test current domain root
-    '/favicon.ico', // Test favicon
   ],
   enablePeriodicChecks: true,
   trackQualityChanges: true,

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -7,7 +7,13 @@
 
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CheckCircle2, Circle, Clock, Target } from 'lucide-react'
@@ -19,12 +25,17 @@ import { MainLayout } from '@/components/layout/MainLayout'
  */
 interface SectionCardProps {
   sectionId: string
-  metadata: typeof SECTION_METADATA[keyof typeof SECTION_METADATA]
+  metadata: (typeof SECTION_METADATA)[keyof typeof SECTION_METADATA]
   isSelected: boolean
   onToggle: (sectionId: string) => void
 }
 
-function SectionCard({ sectionId, metadata, isSelected, onToggle }: SectionCardProps) {
+function SectionCard({
+  sectionId,
+  metadata,
+  isSelected,
+  onToggle,
+}: SectionCardProps) {
   const handleClick = () => {
     onToggle(sectionId)
   }
@@ -37,10 +48,10 @@ function SectionCard({ sectionId, metadata, isSelected, onToggle }: SectionCardP
   }
 
   return (
-    <Card 
+    <Card
       className={`cursor-pointer transition-all duration-200 hover:shadow-lg ${
-        isSelected 
-          ? 'ring-2 ring-primary border-primary bg-primary/5' 
+        isSelected
+          ? 'ring-2 ring-primary border-primary bg-primary/5'
           : 'hover:border-primary/50'
       }`}
       onClick={handleClick}
@@ -58,42 +69,48 @@ function SectionCard({ sectionId, metadata, isSelected, onToggle }: SectionCardP
               {metadata.icon}
             </span>
             <div>
-              <CardTitle 
+              <CardTitle
                 id={`section-${sectionId}-title`}
                 className="text-lg flex items-center gap-2"
               >
                 {metadata.title}
                 {isSelected ? (
-                  <CheckCircle2 className="h-5 w-5 text-primary" aria-label="Izvēlēts" />
+                  <CheckCircle2
+                    className="h-5 w-5 text-primary"
+                    aria-label="Izvēlēts"
+                  />
                 ) : (
-                  <Circle className="h-5 w-5 text-muted-foreground" aria-label="Nav izvēlēts" />
+                  <Circle
+                    className="h-5 w-5 text-muted-foreground"
+                    aria-label="Nav izvēlēts"
+                  />
                 )}
               </CardTitle>
             </div>
           </div>
         </div>
-        <CardDescription 
+        <CardDescription
           id={`section-${sectionId}-description`}
           className="text-sm text-muted-foreground mt-2"
         >
           {metadata.description}
         </CardDescription>
       </CardHeader>
-      
+
       <CardContent className="pt-0">
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-sm">
             <Target className="h-4 w-4 text-muted-foreground" />
             <span>Nepieciešams: {metadata.passingCriteria}</span>
           </div>
-          
+
           <div className="flex items-center gap-2 text-sm">
             <Clock className="h-4 w-4 text-muted-foreground" />
             <span>Aptuvens laiks: {metadata.estimatedTime} min</span>
           </div>
-          
-          <Badge 
-            variant={isSelected ? "default" : "secondary"}
+
+          <Badge
+            variant={isSelected ? 'default' : 'secondary'}
             className="w-fit"
           >
             {isSelected ? 'Izvēlēts' : 'Klikšķiniet, lai izvēlētos'}
@@ -108,7 +125,9 @@ function SectionCard({ sectionId, metadata, isSelected, onToggle }: SectionCardP
  * Main landing page component
  */
 export default function LandingPage() {
-  const [selectedSections, setSelectedSections] = useState<Set<string>>(new Set())
+  const [selectedSections, setSelectedSections] = useState<Set<string>>(
+    new Set()
+  )
   const navigate = useNavigate()
 
   const handleSectionToggle = (sectionId: string) => {
@@ -123,19 +142,28 @@ export default function LandingPage() {
 
   const handleStartTest = () => {
     const sections = Array.from(selectedSections)
-    navigate('/test', { 
-      state: { 
+    navigate('/test', {
+      state: {
         selectedSections: sections,
-        isPartialTest: sections.length < 3 
-      } 
+        isPartialTest: sections.length < 3,
+      },
     })
   }
 
-  const totalEstimatedTime = Array.from(selectedSections).reduce((total, sectionId) => {
-    return total + SECTION_METADATA[sectionId as keyof typeof SECTION_METADATA].estimatedTime
-  }, 0)
+  const totalEstimatedTime = Array.from(selectedSections).reduce(
+    (total, sectionId) => {
+      return (
+        total +
+        SECTION_METADATA[sectionId as keyof typeof SECTION_METADATA]
+          .estimatedTime
+      )
+    },
+    0
+  )
 
-  const sectionArray = Object.entries(SECTION_METADATA).sort(([,a], [,b]) => a.order - b.order)
+  const sectionArray = Object.entries(SECTION_METADATA).sort(
+    ([, a], [, b]) => a.order - b.order
+  )
 
   return (
     <MainLayout>
@@ -146,8 +174,9 @@ export default function LandingPage() {
             Latvijas pilsonības eksāmens
           </h1>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Izvēlieties eksāmena sadaļas, kuras vēlaties kārtot. Jūs varat izvēlēties jebkuru kombināciju - 
-            vienu, divas vai visas trīs sadaļas.
+            Izvēlieties eksāmena sadaļas, kuras vēlaties kārtot. Jūs varat
+            izvēlēties jebkuru kombināciju - vienu, divas vai visas trīs
+            sadaļas.
           </p>
         </div>
 
@@ -170,10 +199,15 @@ export default function LandingPage() {
             <h2 className="text-xl font-semibold mb-4">Izvēlētās sadaļas</h2>
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <h3 className="font-medium mb-2">Sadaļas ({selectedSections.size}):</h3>
+                <h3 className="font-medium mb-2">
+                  Sadaļas ({selectedSections.size}):
+                </h3>
                 <ul className="space-y-1 text-sm">
-                  {Array.from(selectedSections).map(sectionId => {
-                    const metadata = SECTION_METADATA[sectionId as keyof typeof SECTION_METADATA]
+                  {Array.from(selectedSections).map((sectionId) => {
+                    const metadata =
+                      SECTION_METADATA[
+                        sectionId as keyof typeof SECTION_METADATA
+                      ]
                     return (
                       <li key={sectionId} className="flex items-center gap-2">
                         <span>{metadata.icon}</span>
@@ -193,10 +227,9 @@ export default function LandingPage() {
                   <div className="flex items-center gap-2">
                     <Target className="h-4 w-4" />
                     <span>
-                      {selectedSections.size === 3 
-                        ? 'Pilns eksāmens' 
-                        : `Daļējs eksāmens (${selectedSections.size} no 3)`
-                      }
+                      {selectedSections.size === 3
+                        ? 'Pilns eksāmens'
+                        : `Daļējs eksāmens (${selectedSections.size} no 3)`}
                     </span>
                   </div>
                 </div>
@@ -213,15 +246,18 @@ export default function LandingPage() {
             size="lg"
             className="px-8"
           >
-            {selectedSections.size === 0 
-              ? 'Izvēlieties vismaz vienu sadaļu' 
-              : `Sākt eksāmenu (${selectedSections.size} sadaļa${selectedSections.size === 1 ? '' : 's'})`
-            }
+            {selectedSections.size === 0
+              ? 'Izvēlieties vismaz vienu sadaļu'
+              : `Sākt eksāmenu (${selectedSections.size} sadaļa${selectedSections.size === 1 ? '' : 's'})`}
           </Button>
-          
+
           <Button
             variant="outline"
-            onClick={() => setSelectedSections(new Set(['anthem', 'history', 'constitution']))}
+            onClick={() =>
+              setSelectedSections(
+                new Set(['anthem', 'history', 'constitution'])
+              )
+            }
             size="lg"
             className="px-8"
           >
@@ -232,8 +268,8 @@ export default function LandingPage() {
         {/* Help Text */}
         <div className="mt-8 text-center text-sm text-muted-foreground">
           <p>
-            Jūs varat kārtot sadaļas atsevišķi, lai fokusētos uz specifiskām jomām vai 
-            praktikotos pirms pilna eksāmena.
+            Jūs varat kārtot sadaļas atsevišķi, lai fokusētos uz specifiskām
+            jomām vai praktikotos pirms pilna eksāmena.
           </p>
         </div>
       </div>

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -139,7 +139,7 @@ export const SECTION_METADATA = {
     icon: '🎵',
     passingCriteria: '75% precizitāte',
     estimatedTime: 15,
-    order: 1
+    order: 1,
   },
   history: {
     id: 'history',
@@ -148,7 +148,7 @@ export const SECTION_METADATA = {
     icon: '📚',
     passingCriteria: '7 no 10 pareizi',
     estimatedTime: 25,
-    order: 2
+    order: 2,
   },
   constitution: {
     id: 'constitution',
@@ -157,6 +157,6 @@ export const SECTION_METADATA = {
     icon: '⚖️',
     passingCriteria: '5 no 8 pareizi',
     estimatedTime: 20,
-    order: 3
-  }
+    order: 3,
+  },
 } as const

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -445,10 +445,10 @@ export class ErrorLogger {
           sanitized.isInitialization = value
         } else if (typeof value === 'string' || typeof value === 'number') {
           // Handle string and number values
-          (sanitized as any)[key] = value
+          ;(sanitized as any)[key] = value
         } else if (typeof value === 'boolean' && key !== 'isInitialization') {
-          // Handle other boolean values  
-          (sanitized as any)[key] = value
+          // Handle other boolean values
+          ;(sanitized as any)[key] = value
         } else if (key === 'session' && typeof value === 'object') {
           // Safe session data extraction
           const sessionData = value as any

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -33,7 +33,7 @@ export function calculateTestResults(
   const { enabledSections } = testState
 
   // Calculate results only for enabled sections
-  const anthem = enabledSections.anthem 
+  const anthem = enabledSections.anthem
     ? calculateAnthemResults(testState.anthemText)
     : undefined
 
@@ -223,22 +223,37 @@ export function calculateDynamicOverallResult(
 
   // Collect results from enabled sections only
   if (results.anthem && enabledSections.anthem) {
-    enabledResults.push({ passed: results.anthem.passed, score: results.anthem.accuracy })
+    enabledResults.push({
+      passed: results.anthem.passed,
+      score: results.anthem.accuracy,
+    })
   }
   if (results.history && enabledSections.history) {
-    enabledResults.push({ passed: results.history.passed, score: results.history.percentage })
+    enabledResults.push({
+      passed: results.history.passed,
+      score: results.history.percentage,
+    })
   }
   if (results.constitution && enabledSections.constitution) {
-    enabledResults.push({ passed: results.constitution.passed, score: results.constitution.percentage })
+    enabledResults.push({
+      passed: results.constitution.passed,
+      score: results.constitution.percentage,
+    })
   }
 
   // Calculate if all enabled sections passed
-  const allEnabledSectionsPassed = enabledResults.every(result => result.passed)
-  
+  const allEnabledSectionsPassed = enabledResults.every(
+    (result) => result.passed
+  )
+
   // Calculate weighted overall score based on enabled sections
-  const overallScore = enabledResults.length > 0 
-    ? Math.round(enabledResults.reduce((sum, result) => sum + result.score, 0) / enabledResults.length)
-    : 0
+  const overallScore =
+    enabledResults.length > 0
+      ? Math.round(
+          enabledResults.reduce((sum, result) => sum + result.score, 0) /
+            enabledResults.length
+        )
+      : 0
 
   const totalTime = Date.now() - testState.startTime
 
@@ -252,16 +267,18 @@ export function calculateDynamicOverallResult(
     },
     totalTime,
     completedAt: Date.now(),
-    certificateEligible: testConfiguration.isPartialTest 
+    certificateEligible: testConfiguration.isPartialTest
       ? false // Partial tests don't qualify for certificate
       : allEnabledSectionsPassed,
-    partialTestInfo: testConfiguration.isPartialTest ? {
-      completedSections: testConfiguration.sectionNames,
-      totalSections: testConfiguration.totalSections,
-      remainingSections: ['anthem', 'history', 'constitution'].filter(
-        section => !testConfiguration.sectionNames.includes(section)
-      )
-    } : undefined
+    partialTestInfo: testConfiguration.isPartialTest
+      ? {
+          completedSections: testConfiguration.sectionNames,
+          totalSections: testConfiguration.totalSections,
+          remainingSections: ['anthem', 'history', 'constitution'].filter(
+            (section) => !testConfiguration.sectionNames.includes(section)
+          ),
+        }
+      : undefined,
   }
 }
 
@@ -319,7 +336,6 @@ function generateMultipleChoiceAnalysis(
     },
   }
 }
-
 
 /**
  * Generate analytics for dynamic section results (partial tests)
@@ -385,19 +401,25 @@ function generateDynamicRecommendations(
   // Partial test specific recommendations
   if (testConfiguration.isPartialTest) {
     const remainingSections = ['anthem', 'history', 'constitution'].filter(
-      section => !testConfiguration.sectionNames.includes(section)
+      (section) => !testConfiguration.sectionNames.includes(section)
     )
-    
+
     if (remainingSections.length > 0) {
-      const sectionNames = remainingSections.map(section => {
-        switch(section) {
-          case 'anthem': return 'himnas'
-          case 'history': return 'vēstures'
-          case 'constitution': return 'konstitūcijas'
-          default: return section
-        }
-      }).join(', ')
-      
+      const sectionNames = remainingSections
+        .map((section) => {
+          switch (section) {
+            case 'anthem':
+              return 'himnas'
+            case 'history':
+              return 'vēstures'
+            case 'constitution':
+              return 'konstitūcijas'
+            default:
+              return section
+          }
+        })
+        .join(', ')
+
       recommendations.push(`Papildus prakticēt ${sectionNames} sadaļu`)
     }
   }
@@ -408,13 +430,11 @@ function generateDynamicRecommendations(
 /**
  * Identify strengths in partial test results
  */
-function identifyDynamicStrengths(
-  results: {
-    anthem?: AnthemResult
-    history?: MultipleChoiceResult
-    constitution?: MultipleChoiceResult
-  }
-): string[] {
+function identifyDynamicStrengths(results: {
+  anthem?: AnthemResult
+  history?: MultipleChoiceResult
+  constitution?: MultipleChoiceResult
+}): string[] {
   const strengths: string[] = []
 
   if (results.anthem?.passed) {
@@ -448,17 +468,32 @@ function generateDynamicBenchmarks(
   return {
     percentileRanking: 50, // Default to median
     comparedToAverage: {
-      anthem: results.anthem && enabledSections.anthem 
-        ? (results.anthem.accuracy > 75 ? 'above' : results.anthem.accuracy < 60 ? 'below' : 'average')
-        : 'average',
-      history: results.history && enabledSections.history
-        ? (results.history.percentage > 70 ? 'above' : results.history.percentage < 50 ? 'below' : 'average')
-        : 'average',
-      constitution: results.constitution && enabledSections.constitution
-        ? (results.constitution.percentage > 70 ? 'above' : results.constitution.percentage < 50 ? 'below' : 'average')
-        : 'average',
-      timing: 'average' // Default to average for now
-    }
+      anthem:
+        results.anthem && enabledSections.anthem
+          ? results.anthem.accuracy > 75
+            ? 'above'
+            : results.anthem.accuracy < 60
+              ? 'below'
+              : 'average'
+          : 'average',
+      history:
+        results.history && enabledSections.history
+          ? results.history.percentage > 70
+            ? 'above'
+            : results.history.percentage < 50
+              ? 'below'
+              : 'average'
+          : 'average',
+      constitution:
+        results.constitution && enabledSections.constitution
+          ? results.constitution.percentage > 70
+            ? 'above'
+            : results.constitution.percentage < 50
+              ? 'below'
+              : 'average'
+          : 'average',
+      timing: 'average', // Default to average for now
+    },
   }
 }
 
@@ -634,7 +669,7 @@ export function getSectionPassSummary(results: TestResults): {
   sections: Array<{ name: string; passed: boolean; score: number }>
 } {
   const sections = []
-  
+
   if (results.anthem) {
     sections.push({
       name: 'Himna',
@@ -642,7 +677,7 @@ export function getSectionPassSummary(results: TestResults): {
       score: results.anthem.accuracy,
     })
   }
-  
+
   if (results.history) {
     sections.push({
       name: 'Vēsture',
@@ -650,7 +685,7 @@ export function getSectionPassSummary(results: TestResults): {
       score: results.history.percentage,
     })
   }
-  
+
   if (results.constitution) {
     sections.push({
       name: 'Konstitūcija',


### PR DESCRIPTION
## Summary
Enhance the user experience for partial tests by removing navigation distractions, improving visual focus, and ensuring progress indicators only show relevant sections.

## Test plan
- [x] Back navigation button removed from test page
- [x] Partial test indicator centered below subheading with clean styling
- [x] Progress indicators filter to show only enabled sections
- [x] Overall progress calculation reflects only selected sections
- [x] Header separator line removed for cleaner design
- [x] Progress indicator removed from header section
- [x] Development server starts successfully
- [x] All components maintain accessibility and responsive design

🤖 Generated with [Claude Code](https://claude.ai/code)